### PR TITLE
Add OAuth 2.0 Server-to-Server Authentication Support

### DIFF
--- a/.env.oauth-test
+++ b/.env.oauth-test
@@ -1,0 +1,66 @@
+# OAuth Test Configuration for hola.nvim
+# This file contains OAuth configurations for testing with scripts/server.py
+
+# =============================================================================
+# Generic OAuth Provider (Default Environment)
+# =============================================================================
+OAUTH_TOKEN_URL=http://localhost:8000/oauth/token
+OAUTH_CLIENT_ID=test_client_id
+OAUTH_CLIENT_SECRET=test_client_secret
+OAUTH_GRANT_TYPE=client_credentials
+OAUTH_SCOPE=read:users write:orders
+OAUTH_AUTH_METHOD=basic_auth
+OAUTH_CONTENT_TYPE=application/x-www-form-urlencoded
+
+# =============================================================================
+# AWS Cognito Style (COGNITO Environment)
+# =============================================================================
+OAUTH_TOKEN_URL_COGNITO=http://localhost:8000/oauth2/token
+OAUTH_CLIENT_ID_COGNITO=cognito_client_123
+OAUTH_CLIENT_SECRET_COGNITO=cognito_secret_456
+OAUTH_GRANT_TYPE_COGNITO=client_credentials
+OAUTH_AUTH_METHOD_COGNITO=basic_auth
+OAUTH_CONTENT_TYPE_COGNITO=application/x-www-form-urlencoded
+
+# =============================================================================
+# Auth0 Style (AUTH0 Environment)
+# =============================================================================
+OAUTH_TOKEN_URL_AUTH0=http://localhost:8000/oauth/token/auth0
+OAUTH_CLIENT_ID_AUTH0=auth0_client_789
+OAUTH_CLIENT_SECRET_AUTH0=auth0_secret_abc
+OAUTH_GRANT_TYPE_AUTH0=client_credentials
+OAUTH_AUTH_METHOD_AUTH0=json_body
+OAUTH_CONTENT_TYPE_AUTH0=application/json
+OAUTH_AUDIENCE_AUTH0=https://your-api.com
+
+# =============================================================================
+# Apigee Style (APIGEE Environment)
+# =============================================================================
+OAUTH_TOKEN_URL_APIGEE=http://localhost:8000/oauth/v2/accesstoken
+OAUTH_CLIENT_ID_APIGEE=apigee_client_def
+OAUTH_CLIENT_SECRET_APIGEE=apigee_secret_ghi
+OAUTH_GRANT_TYPE_APIGEE=client_credentials
+OAUTH_AUTH_METHOD_APIGEE=form_data
+OAUTH_CONTENT_TYPE_APIGEE=application/x-www-form-urlencoded
+
+# =============================================================================
+# Multi-Environment Example (STAGING/DEV)
+# =============================================================================
+OAUTH_TOKEN_URL_STAGING=http://localhost:8000/oauth/token
+OAUTH_CLIENT_ID_STAGING=staging_client_456
+OAUTH_CLIENT_SECRET_STAGING=staging_secret_789
+OAUTH_GRANT_TYPE_STAGING=client_credentials
+OAUTH_AUTH_METHOD_STAGING=basic_auth
+
+OAUTH_TOKEN_URL_DEV=http://localhost:8000/oauth/token
+OAUTH_CLIENT_ID_DEV=dev_client_123
+OAUTH_CLIENT_SECRET_DEV=dev_secret_456
+OAUTH_GRANT_TYPE_DEV=client_credentials
+OAUTH_AUTH_METHOD_DEV=basic_auth
+
+# =============================================================================
+# Other Variables for Testing Mixed Authentication
+# =============================================================================
+API_KEY=secret-api-key-123
+USER_EMAIL=test@example.com
+ANALYTICS_API_KEY=analytics-key-456

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ deps/*
 result/
 .DS_Store
 .opencode
+.env

--- a/OAUTH.md
+++ b/OAUTH.md
@@ -1,0 +1,565 @@
+# OAuth 2.0 Server-to-Server Authentication in hola.nvim
+
+This guide covers OAuth 2.0 server-to-server authentication flows in hola.nvim, enabling seamless authentication with API gateways like AWS Cognito, Auth0, Apigee, and custom OAuth providers without browser interaction.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Supported OAuth Flows](#supported-oauth-flows)
+- [Quick Start](#quick-start)
+- [Configuration](#configuration)
+- [Provider Examples](#provider-examples)
+- [Usage in HTTP Files](#usage-in-http-files)
+- [Token Management](#token-management)
+- [Multi-Environment Support](#multi-environment-support)
+- [Commands](#commands)
+- [Troubleshooting](#troubleshooting)
+
+## Overview
+
+OAuth 2.0 server-to-server authentication allows applications to authenticate directly with APIs without user intervention. This is perfect for:
+
+- **API Gateway Integration**: AWS Cognito, Auth0, Apigee
+- **Microservices Authentication**: Service-to-service communication
+- **Enterprise APIs**: Corporate authentication systems
+- **Headless Environments**: CI/CD pipelines, server deployments
+
+## Supported OAuth Flows
+
+### Client Credentials Flow (Primary)
+
+The most common server-to-server flow where the client acts on its own behalf.
+
+```
+Client → OAuth Server: POST /oauth/token
+                      grant_type=client_credentials
+                      client_id=xxx
+                      client_secret=yyy
+
+OAuth Server → Client: {
+                        "access_token": "...",
+                        "token_type": "Bearer",
+                        "expires_in": 3600
+                      }
+```
+
+### Resource Owner Password Credentials (ROPC)
+
+Used when the client has user credentials and can authenticate directly (less common).
+
+## Quick Start
+
+### 1. Configure Your Provider
+
+Create or update your `.env` file:
+
+```bash
+# Basic OAuth Configuration
+OAUTH_TOKEN_URL=https://auth.example.com/oauth/token
+OAUTH_CLIENT_ID=your_client_id
+OAUTH_CLIENT_SECRET=your_client_secret
+OAUTH_GRANT_TYPE=client_credentials
+OAUTH_SCOPE=read:users write:orders
+```
+
+### 2. Use OAuth Tokens in HTTP Files
+
+```http
+### Get user data with OAuth
+GET https://api.example.com/v1/users
+Authorization: Bearer {{OAUTH_TOKEN}}
+Content-Type: application/json
+
+###
+
+### Create order with OAuth
+POST https://api.example.com/v1/orders
+Authorization: Bearer {{OAUTH_TOKEN}}
+Content-Type: application/json
+
+{
+  "product_id": "12345",
+  "quantity": 2
+}
+```
+
+### 3. Send Requests
+
+Use `:HolaSend` as usual. hola.nvim will:
+1. Detect the `{{OAUTH_TOKEN}}` template
+2. Check for cached valid tokens
+3. Automatically obtain new tokens if needed
+4. Replace the template with the actual token
+5. Execute the HTTP request
+
+## Configuration
+
+OAuth configuration is handled through environment variables in `.env` files. Here are all supported options:
+
+### Basic Configuration
+
+```bash
+# Required Settings
+OAUTH_TOKEN_URL=https://auth.example.com/oauth/token    # OAuth token endpoint
+OAUTH_CLIENT_ID=your_client_id                          # OAuth client ID
+OAUTH_CLIENT_SECRET=your_client_secret                  # OAuth client secret
+
+# Optional Settings
+OAUTH_GRANT_TYPE=client_credentials                     # Grant type (default: client_credentials)
+OAUTH_SCOPE=read:users write:orders                    # Requested scopes
+OAUTH_AUTH_METHOD=basic_auth                           # Authentication method
+OAUTH_CONTENT_TYPE=application/x-www-form-urlencoded   # Request content type
+```
+
+### Authentication Methods
+
+Different OAuth providers expect different authentication formats:
+
+#### `basic_auth` (Default)
+Credentials sent via Authorization header:
+```bash
+OAUTH_AUTH_METHOD=basic_auth
+OAUTH_CONTENT_TYPE=application/x-www-form-urlencoded
+```
+
+#### `form_data`
+Credentials sent in POST body:
+```bash
+OAUTH_AUTH_METHOD=form_data
+OAUTH_CONTENT_TYPE=application/x-www-form-urlencoded
+```
+
+#### `json_body`
+Credentials sent as JSON in POST body:
+```bash
+OAUTH_AUTH_METHOD=json_body
+OAUTH_CONTENT_TYPE=application/json
+```
+
+#### `header_bearer`
+Credentials sent as Bearer token in Authorization header:
+```bash
+OAUTH_AUTH_METHOD=header_bearer
+```
+
+### Advanced Configuration
+
+```bash
+# Custom Headers
+OAUTH_CUSTOM_HEADERS=X-API-Version:2.0,X-Source:hola-nvim
+
+# Provider-specific parameters
+OAUTH_AUDIENCE=https://your-api.com                    # Auth0 audience parameter
+OAUTH_USERNAME=service_account                         # ROPC flow username
+OAUTH_PASSWORD=service_password                        # ROPC flow password
+```
+
+## Provider Examples
+
+### AWS Cognito
+
+AWS Cognito uses Basic Auth with form-encoded body:
+
+```bash
+# .env for AWS Cognito
+OAUTH_TOKEN_URL=https://your-domain.auth.us-east-1.amazoncognito.com/oauth2/token
+OAUTH_CLIENT_ID=your_cognito_client_id
+OAUTH_CLIENT_SECRET=your_cognito_client_secret
+OAUTH_GRANT_TYPE=client_credentials
+OAUTH_AUTH_METHOD=basic_auth
+OAUTH_CONTENT_TYPE=application/x-www-form-urlencoded
+```
+
+**HTTP Request Example:**
+```http
+POST https://your-domain.auth.us-east-1.amazoncognito.com/oauth2/token
+Authorization: Basic base64(client_id:client_secret)
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=client_credentials&scope=your/scope
+```
+
+### Auth0
+
+Auth0 uses JSON body with client credentials:
+
+```bash
+# .env for Auth0
+OAUTH_TOKEN_URL=https://your-domain.auth0.com/oauth/token
+OAUTH_CLIENT_ID=your_auth0_client_id
+OAUTH_CLIENT_SECRET=your_auth0_client_secret
+OAUTH_GRANT_TYPE=client_credentials
+OAUTH_AUTH_METHOD=json_body
+OAUTH_CONTENT_TYPE=application/json
+OAUTH_AUDIENCE=https://your-api.com
+```
+
+**HTTP Request Example:**
+```http
+POST https://your-domain.auth0.com/oauth/token
+Content-Type: application/json
+
+{
+  "grant_type": "client_credentials",
+  "client_id": "your_auth0_client_id",
+  "client_secret": "your_auth0_client_secret",
+  "audience": "https://your-api.com"
+}
+```
+
+### Apigee
+
+Apigee uses form data in the request body:
+
+```bash
+# .env for Apigee
+OAUTH_TOKEN_URL=https://your-org-env.apigee.net/oauth/v2/accesstoken
+OAUTH_CLIENT_ID=your_apigee_client_id
+OAUTH_CLIENT_SECRET=your_apigee_client_secret
+OAUTH_GRANT_TYPE=client_credentials
+OAUTH_AUTH_METHOD=form_data
+OAUTH_CONTENT_TYPE=application/x-www-form-urlencoded
+```
+
+**HTTP Request Example:**
+```http
+POST https://your-org-env.apigee.net/oauth/v2/accesstoken
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=client_credentials&client_id=your_client_id&client_secret=your_secret
+```
+
+### Custom OAuth Provider
+
+For custom OAuth providers, adjust the configuration as needed:
+
+```bash
+# .env for Custom Provider
+OAUTH_TOKEN_URL=https://custom-auth.example.com/token
+OAUTH_CLIENT_ID=custom_client_123
+OAUTH_CLIENT_SECRET=custom_secret_456
+OAUTH_GRANT_TYPE=client_credentials
+OAUTH_AUTH_METHOD=basic_auth
+OAUTH_SCOPE=api:read api:write
+OAUTH_CUSTOM_HEADERS=X-Provider:custom,X-Version:v1
+```
+
+## Usage in HTTP Files
+
+### Basic Usage
+
+Use `{{OAUTH_TOKEN}}` anywhere in your HTTP files:
+
+```http
+### Get user profile
+GET https://api.example.com/v1/user/profile
+Authorization: Bearer {{OAUTH_TOKEN}}
+Content-Type: application/json
+
+###
+
+### Update user settings
+PUT https://api.example.com/v1/user/settings
+Authorization: Bearer {{OAUTH_TOKEN}}
+Content-Type: application/json
+
+{
+  "theme": "dark",
+  "notifications": true
+}
+```
+
+### Headers and Body
+
+OAuth tokens can be used in any part of the request:
+
+```http
+### Custom authorization header
+GET https://api.example.com/data
+X-Auth-Token: {{OAUTH_TOKEN}}
+
+###
+
+### Token in request body
+POST https://api.example.com/graphql
+Content-Type: application/json
+
+{
+  "query": "{ user { name } }",
+  "variables": {},
+  "extensions": {
+    "authorization": "{{OAUTH_TOKEN}}"
+  }
+}
+```
+
+## Token Management
+
+### Automatic Token Handling
+
+hola.nvim handles OAuth tokens automatically:
+
+1. **Token Detection**: When `{{OAUTH_TOKEN*}}` is found in a request
+2. **Cache Check**: Checks if a valid cached token exists
+3. **Token Acquisition**: Fetches new token if needed using OAuth config
+4. **Token Injection**: Replaces template with actual token
+5. **Request Execution**: Executes the HTTP request with the token
+
+### Token Caching
+
+Tokens are cached securely on disk:
+
+**Cache Location**: `~/.local/share/nvim/hola/oauth_cache.json`
+
+**Cache Structure**:
+```json
+{
+  "default": {
+    "access_token": "eyJhbGciOiJSUzI1NiIs...",
+    "token_type": "Bearer",
+    "expires_at": 1234567890,
+    "acquired_at": 1234564290
+  },
+  "staging": {
+    "access_token": "eyJhbGciOiJIUzI1NiIs...",
+    "expires_at": 1234567890
+  }
+}
+```
+
+### Smart Token Refresh
+
+- **Automatic Refresh**: Tokens are refreshed 5 minutes before expiration
+- **Failure Recovery**: Invalid tokens are automatically cleared and re-acquired
+- **Memory Caching**: Current tokens are kept in memory for performance
+- **Secure Storage**: Cache files use restrictive permissions (600)
+
+## Multi-Environment Support
+
+Configure different environments by adding suffixes to environment variables:
+
+### Environment Configuration
+
+```bash
+# Production (default)
+OAUTH_TOKEN_URL=https://auth.example.com/oauth/token
+OAUTH_CLIENT_ID=prod_client_id
+OAUTH_CLIENT_SECRET=prod_client_secret
+
+# Staging
+OAUTH_TOKEN_URL_STAGING=https://staging-auth.example.com/oauth/token
+OAUTH_CLIENT_ID_STAGING=staging_client_id
+OAUTH_CLIENT_SECRET_STAGING=staging_client_secret
+
+# Development
+OAUTH_TOKEN_URL_DEV=https://dev-auth.example.com/oauth/token
+OAUTH_CLIENT_ID_DEV=dev_client_id
+OAUTH_CLIENT_SECRET_DEV=dev_client_secret
+```
+
+### Environment Usage
+
+```http
+### Production API call
+GET https://api.example.com/v1/users
+Authorization: Bearer {{OAUTH_TOKEN}}
+
+### Staging API call
+GET https://staging-api.example.com/v1/users
+Authorization: Bearer {{OAUTH_TOKEN_STAGING}}
+
+### Development API call
+GET https://dev-api.example.com/v1/users
+Authorization: Bearer {{OAUTH_TOKEN_DEV}}
+```
+
+## Commands
+
+hola.nvim provides several commands for managing OAuth tokens:
+
+### `:HolaOAuthStatus`
+
+Show current OAuth token status for all environments:
+
+```
+OAuth Token Status:
+  default: Valid (expires in 2h 15m)
+  staging: Valid (expires in 45m)
+  dev: Expired (refresh needed)
+```
+
+### `:HolaOAuthRefresh [environment]`
+
+Manually refresh OAuth tokens:
+
+```vim
+:HolaOAuthRefresh          " Refresh all environments
+:HolaOAuthRefresh staging  " Refresh only staging environment
+```
+
+### `:HolaOAuthClear [environment]`
+
+Clear cached OAuth tokens to force re-authentication:
+
+```vim
+:HolaOAuthClear           " Clear all cached tokens
+:HolaOAuthClear staging   " Clear only staging tokens
+```
+
+### `:HolaOAuthConfig [environment]`
+
+Interactive OAuth configuration setup (future feature):
+
+```
+Enter OAuth Token URL: https://auth.example.com/oauth/token
+Enter Client ID: your_client_id
+Enter Client Secret: [hidden input]
+Select Grant Type:
+  1. client_credentials (recommended)
+  2. password
+Select Auth Method:
+  1. basic_auth (Authorization header)
+  2. form_data (POST body form)
+  3. json_body (POST body JSON)
+Enter Scope (optional): read:users write:orders
+Environment suffix (optional, e.g., _STAGING):
+
+Configuration saved to .env file.
+```
+
+## Troubleshooting
+
+### Common Issues
+
+#### "Missing OAuth configuration"
+```
+Error: Missing OAuth configuration for environment: default
+```
+
+**Solution**: Ensure your `.env` file contains the required OAuth variables:
+```bash
+OAUTH_TOKEN_URL=https://auth.example.com/oauth/token
+OAUTH_CLIENT_ID=your_client_id
+OAUTH_CLIENT_SECRET=your_client_secret
+```
+
+#### "OAuth request failed with status 401"
+```
+Error: OAuth request failed with status 401: invalid_client
+```
+
+**Solutions**:
+- Verify client ID and secret are correct
+- Check that the OAuth endpoint URL is correct
+- Ensure the authentication method matches your provider's requirements
+
+#### "Invalid OAuth response format"
+```
+Error: Invalid OAuth response format
+```
+
+**Solutions**:
+- Verify the OAuth endpoint returns valid JSON
+- Check that the endpoint returns an `access_token` field
+- Ensure the Content-Type is correctly set for your provider
+
+### Environment Variable Issues
+
+#### Variables not being loaded
+1. Ensure `.env` file is in your current working directory
+2. Check that variable names are spelled correctly
+3. Verify there are no spaces around the `=` sign in `.env` file
+
+#### Wrong environment being used
+1. Check the suffix in your template variable (`{{OAUTH_TOKEN_STAGING}}`)
+2. Ensure corresponding environment variables exist (`OAUTH_*_STAGING`)
+3. Verify variable names match exactly (case-sensitive)
+
+### Token Cache Issues
+
+#### Tokens not being cached
+1. Check that the cache directory exists: `~/.local/share/nvim/hola/`
+2. Verify file permissions allow writing
+3. Check for disk space issues
+
+#### Stale tokens not refreshing
+1. Use `:HolaOAuthClear` to force token refresh
+2. Check system clock for time synchronization issues
+3. Verify the OAuth response includes `expires_in` field
+
+### Provider-Specific Issues
+
+#### AWS Cognito
+- Ensure the domain format is correct: `your-domain.auth.region.amazoncognito.com`
+- Verify the client is configured for "Client credentials" grant type
+- Check that required scopes are configured in Cognito
+
+#### Auth0
+- Ensure the `audience` parameter matches your API identifier
+- Verify the application type is set to "Machine to Machine"
+- Check that the client has been granted the required scopes
+
+#### Apigee
+- Verify the organization and environment in the URL
+- Ensure the OAuth policy is properly configured in Apigee
+- Check that the client credentials are correctly registered
+
+### Debug Mode
+
+Enable detailed logging for troubleshooting:
+
+```lua
+require("hola").setup({
+  oauth = {
+    debug = true  -- Enable OAuth debug logging
+  }
+})
+```
+
+This will log OAuth requests and responses to help identify issues.
+
+## Security Considerations
+
+### Credential Storage
+- Never commit client secrets to version control
+- Use environment variables or encrypted storage for secrets
+- Consider using HashiCorp Vault for enterprise secret management
+
+### Token Security
+- Cache files use restrictive permissions (600)
+- Tokens are automatically cleared on authentication failures
+- Consider token rotation policies for production environments
+
+### Network Security
+- Always use HTTPS for OAuth endpoints
+- Validate SSL certificates in production
+- Consider network-level restrictions for sensitive environments
+
+## Integration with Existing Features
+
+OAuth 2.0 authentication integrates seamlessly with hola.nvim's existing features:
+
+### Variable Resolution Priority
+When processing templates, hola.nvim checks sources in this order:
+
+1. **OAuth Tokens**: `{{OAUTH_TOKEN*}}` patterns
+2. **HashiCorp Vault**: `{{vault:secret/path#field}}`
+3. **Environment Variables**: `{{VARIABLE_NAME}}`
+4. **`.env` Files**: Variables from `.env` file
+
+### Mixed Authentication
+You can combine OAuth with other authentication methods:
+
+```http
+### OAuth + API Key
+GET https://api.example.com/analytics
+Authorization: Bearer {{OAUTH_TOKEN}}
+X-Analytics-Key: {{ANALYTICS_API_KEY}}
+
+### OAuth + Vault Secrets
+POST https://api.example.com/secure
+Authorization: Bearer {{OAUTH_TOKEN}}
+X-Database-Password: {{vault:secret/db#password}}
+```
+
+This comprehensive OAuth integration makes hola.nvim a powerful tool for modern API development and testing workflows.

--- a/README.md
+++ b/README.md
@@ -205,6 +205,37 @@ X-API-Key: {{API_KEY}}
 
 Note: The `Authorization: ApiKey` format ensures consistent formatting, while custom headers like `X-API-Key` are passed through unchanged.
 
+### OAuth 2.0 Server-to-Server Authentication
+
+`hola.nvim` supports OAuth 2.0 client credentials flow for seamless server-to-server authentication with API gateways and enterprise services without requiring browser interaction.
+
+**OAuth Token Example:**
+```http
+GET https://api.example.com/protected
+Authorization: Bearer {{OAUTH_TOKEN}}
+```
+
+**Multi-environment Support:**
+```http
+### Development API
+GET https://dev-api.example.com/data
+Authorization: Bearer {{OAUTH_TOKEN_DEV}}
+
+### Production API
+GET https://api.example.com/data
+Authorization: Bearer {{OAUTH_TOKEN}}
+```
+
+**Supported Providers:**
+- AWS Cognito
+- Auth0
+- Apigee
+- Custom OAuth 2.0 providers
+
+OAuth tokens are automatically obtained, cached, and refreshed as needed. Configuration is handled through `.env` files with provider-specific settings.
+
+> See [OAUTH.md](OAUTH.md) for detailed OAuth configuration, supported flows, and provider examples.
+
 ## Power Up Your Requests with Variables and Secrets! ⚙️
 
 `hola.nvim` supports multiple ways to inject dynamic values into your `.http` files:

--- a/examples.http
+++ b/examples.http
@@ -68,3 +68,69 @@ Custom-Header: sardina
 ### Generate a password
 POST https://api.malev.xyz/api/password
 
+### =============================================================================
+### OAuth 2.0 Testing (use with scripts/server.py and .env.oauth-test)
+### =============================================================================
+
+### OAuth Test - Generic Provider (Default Environment)
+GET http://localhost:8000/oauth-test
+Authorization: Bearer {{OAUTH_TOKEN}}
+Accept: application/json
+
+### OAuth Test - AWS Cognito Style
+GET http://localhost:8000/oauth-test
+Authorization: Bearer {{OAUTH_TOKEN_COGNITO}}
+Accept: application/json
+
+### OAuth Test - Auth0 Style
+GET http://localhost:8000/oauth-test
+Authorization: Bearer {{OAUTH_TOKEN_AUTH0}}
+Accept: application/json
+
+### OAuth Test - Apigee Style
+GET http://localhost:8000/oauth-test
+Authorization: Bearer {{OAUTH_TOKEN_APIGEE}}
+Accept: application/json
+
+### OAuth Test - Multi-Environment (Staging)
+GET http://localhost:8000/oauth-test
+Authorization: Bearer {{OAUTH_TOKEN_STAGING}}
+Accept: application/json
+
+### OAuth Test - Multi-Environment (Dev)
+GET http://localhost:8000/oauth-test
+Authorization: Bearer {{OAUTH_TOKEN_DEV}}
+Accept: application/json
+
+### OAuth Mixed with Traditional Variables
+POST http://localhost:8000/echo
+Authorization: Bearer {{OAUTH_TOKEN}}
+X-API-Key: {{API_KEY}}
+X-User-Email: {{USER_EMAIL}}
+Content-Type: application/json
+
+{
+  "message": "Testing OAuth with traditional variables",
+  "api_key": "{{API_KEY}}",
+  "oauth_env": "default"
+}
+
+### OAuth Token in Request Body (GraphQL Example)
+POST http://localhost:8000/echo
+Content-Type: application/json
+
+{
+  "query": "{ user { name email } }",
+  "variables": {},
+  "extensions": {
+    "authorization": "{{OAUTH_TOKEN_COGNITO}}"
+  }
+}
+
+### OAuth Custom Headers
+GET http://localhost:8000/oauth-test
+Authorization: Bearer {{OAUTH_TOKEN_AUTH0}}
+X-OAuth-Provider: auth0
+X-Environment: production
+Accept: application/json
+

--- a/lua/hola/oauth.lua
+++ b/lua/hola/oauth.lua
@@ -1,0 +1,254 @@
+local curl = require('plenary.curl')
+
+local M = {}
+
+-- Memory cache for OAuth tokens (session-scoped)
+local oauth_cache = {}
+
+-- Cache configuration
+local CACHE_TTL_SECONDS = 300 -- 5 minutes buffer before expiration
+local OAUTH_TIMEOUT_SECONDS = 10
+
+--- Check if cached token is still valid
+--- @param cached_token table Cached token data
+--- @return boolean True if cache is valid
+local function is_cache_valid(cached_token)
+  if not cached_token then
+    return false
+  end
+
+  -- Use the token's actual expiration time with buffer
+  local buffer_time = CACHE_TTL_SECONDS
+  return os.time() < (cached_token.expires_at - buffer_time)
+end
+
+--- Store token in cache
+--- @param env_suffix string Environment suffix (default, staging, etc.)
+--- @param token_data table Token response data
+local function cache_token(env_suffix, token_data)
+  local expires_at = os.time() + (token_data.expires_in or 3600)
+
+  oauth_cache[env_suffix] = {
+    access_token = token_data.access_token,
+    token_type = token_data.token_type or 'Bearer',
+    expires_at = expires_at,
+    acquired_at = os.time(),
+  }
+end
+
+--- Get token from cache
+--- @param env_suffix string Environment suffix
+--- @return string|nil Cached token or nil
+local function get_cached_token(env_suffix)
+  local cached = oauth_cache[env_suffix]
+  if is_cache_valid(cached) then
+    return cached.access_token
+  else
+    -- Clean up expired cache entry
+    oauth_cache[env_suffix] = nil
+    return nil
+  end
+end
+
+--- Build Basic Auth header
+--- @param client_id string OAuth client ID
+--- @param client_secret string OAuth client secret
+--- @return string Basic auth header value
+local function build_basic_auth(client_id, client_secret)
+  local credentials = client_id .. ':' .. client_secret
+  local encoded = vim.fn.substitute(vim.fn.system('echo -n "' .. credentials .. '" | base64'), '\n', '', 'g')
+  return 'Basic ' .. encoded
+end
+
+--- Make OAuth token request
+--- @param config table OAuth configuration
+--- @return table HTTP response
+local function make_oauth_request(config)
+  local headers = {}
+  local body = ''
+
+  if config.auth_method == 'basic_auth' then
+    headers['Authorization'] = build_basic_auth(config.client_id, config.client_secret)
+    headers['Content-Type'] = config.content_type or 'application/x-www-form-urlencoded'
+    body = 'grant_type=' .. config.grant_type
+    if config.scope then
+      body = body .. '&scope=' .. config.scope
+    end
+  elseif config.auth_method == 'form_data' then
+    headers['Content-Type'] = config.content_type or 'application/x-www-form-urlencoded'
+    body = 'grant_type=' .. config.grant_type ..
+           '&client_id=' .. config.client_id ..
+           '&client_secret=' .. config.client_secret
+    if config.scope then
+      body = body .. '&scope=' .. config.scope
+    end
+  elseif config.auth_method == 'json_body' then
+    headers['Content-Type'] = config.content_type or 'application/json'
+    local request_data = {
+      grant_type = config.grant_type,
+      client_id = config.client_id,
+      client_secret = config.client_secret
+    }
+    if config.scope then
+      request_data.scope = config.scope
+    end
+    if config.audience then
+      request_data.audience = config.audience
+    end
+    body = vim.fn.json_encode(request_data)
+  else
+    error('Unsupported OAuth auth method: ' .. (config.auth_method or 'nil'))
+  end
+
+  -- Add custom headers if specified
+  if config.custom_headers then
+    for header_pair in config.custom_headers:gmatch('[^,]+') do
+      local key, value = header_pair:match('([^:]+):(.+)')
+      if key and value then
+        headers[vim.trim(key)] = vim.trim(value)
+      end
+    end
+  end
+
+  local response = curl.post(config.token_url, {
+    headers = headers,
+    body = body,
+    timeout = OAUTH_TIMEOUT_SECONDS * 1000, -- convert to milliseconds
+  })
+
+  return response
+end
+
+--- Get OAuth configuration for environment
+--- @param env_suffix string Environment suffix (default, staging, etc.)
+--- @param env_sources table Array of environment variable sources to search
+--- @return table OAuth configuration
+local function get_oauth_config(env_suffix, env_sources)
+  local suffix = env_suffix == 'default' and '' or '_' .. env_suffix:upper()
+
+  -- Helper function to find value in multiple sources
+  local function find_env_value(key)
+    for _, source in ipairs(env_sources or {}) do
+      if source and source[key] then
+        return source[key]
+      end
+    end
+    return nil
+  end
+
+  local config = {
+    token_url = find_env_value('OAUTH_TOKEN_URL' .. suffix),
+    client_id = find_env_value('OAUTH_CLIENT_ID' .. suffix),
+    client_secret = find_env_value('OAUTH_CLIENT_SECRET' .. suffix),
+    grant_type = find_env_value('OAUTH_GRANT_TYPE' .. suffix) or 'client_credentials',
+    scope = find_env_value('OAUTH_SCOPE' .. suffix),
+    auth_method = find_env_value('OAUTH_AUTH_METHOD' .. suffix) or 'basic_auth',
+    content_type = find_env_value('OAUTH_CONTENT_TYPE' .. suffix),
+    audience = find_env_value('OAUTH_AUDIENCE' .. suffix),
+    custom_headers = find_env_value('OAUTH_CUSTOM_HEADERS' .. suffix),
+  }
+
+  if not config.token_url or not config.client_id or not config.client_secret then
+    error('Missing OAuth configuration for environment: ' .. env_suffix)
+  end
+
+  return config
+end
+
+--- Get OAuth token for environment
+--- @param env_suffix string|nil Environment suffix (defaults to 'default')
+--- @param env_sources table|nil Array of environment variable sources to search
+--- @return string|nil, string|nil access_token, error_message
+function M.get_token(env_suffix, env_sources)
+  env_suffix = env_suffix or 'default'
+  env_sources = env_sources or {vim.env}
+
+  -- Check cache first
+  local cached_token = get_cached_token(env_suffix)
+  if cached_token then
+    return cached_token, nil
+  end
+
+  -- Get OAuth configuration
+  local ok, config = pcall(get_oauth_config, env_suffix, env_sources)
+  if not ok then
+    return nil, config -- config contains the error message
+  end
+
+  -- Make OAuth request
+  local response = make_oauth_request(config)
+
+  if response.status ~= 200 then
+    local error_msg = 'OAuth request failed with status ' .. response.status
+    if response.body then
+      local ok_parse, error_data = pcall(vim.fn.json_decode, response.body)
+      if ok_parse and error_data.error then
+        error_msg = error_msg .. ': ' .. error_data.error
+        if error_data.error_description then
+          error_msg = error_msg .. ' - ' .. error_data.error_description
+        end
+      end
+    end
+    return nil, error_msg
+  end
+
+  local ok_parse, token_data = pcall(vim.fn.json_decode, response.body)
+  if not ok_parse or not token_data.access_token then
+    return nil, 'Invalid OAuth response format'
+  end
+
+  -- Cache the token
+  cache_token(env_suffix, token_data)
+
+  return token_data.access_token, nil
+end
+
+--- Clear cached OAuth tokens
+--- @param env_suffix string|nil Environment suffix (clears all if nil)
+function M.clear_cache(env_suffix)
+  if env_suffix then
+    oauth_cache[env_suffix] = nil
+  else
+    oauth_cache = {}
+  end
+end
+
+--- Get OAuth token status for all environments
+--- @return table Status information for all cached tokens
+function M.get_status()
+  local status = {}
+
+  for env, token_data in pairs(oauth_cache) do
+    status[env] = {
+      expires_at = token_data.expires_at,
+      acquired_at = token_data.acquired_at,
+      expired = not is_cache_valid(token_data),
+      token_type = token_data.token_type or 'Bearer'
+    }
+  end
+
+  return status
+end
+
+--- Get cache statistics (useful for debugging)
+--- @return table Cache statistics
+function M.get_cache_stats()
+  local stats = {
+    total_entries = 0,
+    valid_entries = 0,
+    expired_entries = 0,
+  }
+
+  for _, cached_token in pairs(oauth_cache) do
+    stats.total_entries = stats.total_entries + 1
+    if is_cache_valid(cached_token) then
+      stats.valid_entries = stats.valid_entries + 1
+    else
+      stats.expired_entries = stats.expired_entries + 1
+    end
+  end
+
+  return stats
+end
+
+return M

--- a/scripts/server.py
+++ b/scripts/server.py
@@ -11,6 +11,16 @@ PASSWORD = "secret"
 BEARER_TOKEN = "abc123-def456-ghi789"
 API_KEY = "secret-api-key-123"
 
+# OAuth Configuration
+OAUTH_CLIENT_ID = "test_client_id"
+OAUTH_CLIENT_SECRET = "test_client_secret"
+OAUTH_COGNITO_CLIENT_ID = "cognito_client_123"
+OAUTH_COGNITO_CLIENT_SECRET = "cognito_secret_456"
+OAUTH_AUTH0_CLIENT_ID = "auth0_client_789"
+OAUTH_AUTH0_CLIENT_SECRET = "auth0_secret_abc"
+OAUTH_APIGEE_CLIENT_ID = "apigee_client_def"
+OAUTH_APIGEE_CLIENT_SECRET = "apigee_secret_ghi"
+
 class SimpleHandler(BaseHTTPRequestHandler):
     def _log_headers(self):
         """Helper: log incoming request headers"""
@@ -48,6 +58,36 @@ class SimpleHandler(BaseHTTPRequestHandler):
         self.send_header("Content-Type", "application/json")
         self.end_headers()
         self.wfile.write(b'{"error":"Invalid API key"}')
+
+    def _validate_basic_auth(self, expected_client_id, expected_client_secret):
+        """Helper: validate OAuth Basic Auth credentials"""
+        auth_header = self.headers.get("Authorization")
+        if not auth_header or not auth_header.startswith("Basic "):
+            return False
+
+        try:
+            encoded = auth_header.split(" ", 1)[1]
+            decoded = base64.b64decode(encoded).decode("utf-8")
+            client_id, client_secret = decoded.split(":", 1)
+            return client_id == expected_client_id and client_secret == expected_client_secret
+        except Exception:
+            return False
+
+    def _oauth_error(self, error, description=""):
+        """Helper: send OAuth error response"""
+        response = {"error": error}
+        if description:
+            response["error_description"] = description
+        self._send_json(response, 400)
+
+    def _oauth_success(self, token_suffix=""):
+        """Helper: send OAuth success response"""
+        self._send_json({
+            "access_token": f"oauth_token_{token_suffix}_{int(time.time())}",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "scope": "read:users write:orders"
+        })
 
     def do_GET(self):
         self._log_headers()
@@ -92,6 +132,26 @@ class SimpleHandler(BaseHTTPRequestHandler):
                 self._send_json({"apikey": "success", "key": "valid"})
             else:
                 self._unauthorized_apikey()
+        elif self.path == "/oauth-test":
+            # GET endpoint to test OAuth tokens
+            auth_header = self.headers.get("Authorization")
+            if not auth_header or not auth_header.startswith("Bearer "):
+                self._unauthorized_bearer()
+                return
+
+            token = auth_header.split(" ", 1)[1].strip()
+            if token.startswith("oauth_token_"):
+                # Extract provider from token (oauth_token_generic_123456)
+                parts = token.split("_")
+                provider = parts[2] if len(parts) >= 3 else "unknown"
+                self._send_json({
+                    "oauth_test": "success",
+                    "token_valid": True,
+                    "provider": provider,
+                    "token_prefix": token[:20] + "..."
+                })
+            else:
+                self._unauthorized_bearer()
         else:
             self.send_response(404)
             self.end_headers()
@@ -121,6 +181,71 @@ class SimpleHandler(BaseHTTPRequestHandler):
                 self._send_json({"secure": "success", "user": username})
             else:
                 self._unauthorized()
+        elif self.path == "/oauth/token":
+            # Generic OAuth token endpoint (Basic Auth + form data)
+            content_length = int(self.headers.get('Content-Length', 0))
+            body = self.rfile.read(content_length).decode('utf-8')
+
+            if "grant_type=client_credentials" not in body:
+                self._oauth_error("unsupported_grant_type", "Only client_credentials supported")
+                return
+
+            if self._validate_basic_auth(OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET):
+                self._oauth_success("generic")
+            else:
+                self._oauth_error("invalid_client", "Invalid client credentials")
+        elif self.path == "/oauth2/token":
+            # AWS Cognito style (Basic Auth + form data)
+            content_length = int(self.headers.get('Content-Length', 0))
+            body = self.rfile.read(content_length).decode('utf-8')
+
+            if "grant_type=client_credentials" not in body:
+                self._oauth_error("unsupported_grant_type")
+                return
+
+            if self._validate_basic_auth(OAUTH_COGNITO_CLIENT_ID, OAUTH_COGNITO_CLIENT_SECRET):
+                self._oauth_success("cognito")
+            else:
+                self._oauth_error("invalid_client")
+        elif self.path == "/oauth/token/auth0":
+            # Auth0 style (JSON body)
+            content_length = int(self.headers.get('Content-Length', 0))
+            body = self.rfile.read(content_length).decode('utf-8')
+
+            try:
+                data = json.loads(body)
+                if data.get("grant_type") != "client_credentials":
+                    self._oauth_error("unsupported_grant_type")
+                    return
+
+                if (data.get("client_id") == OAUTH_AUTH0_CLIENT_ID and
+                    data.get("client_secret") == OAUTH_AUTH0_CLIENT_SECRET):
+                    self._oauth_success("auth0")
+                else:
+                    self._oauth_error("invalid_client")
+            except json.JSONDecodeError:
+                self._oauth_error("invalid_request", "Invalid JSON body")
+        elif self.path == "/oauth/v2/accesstoken":
+            # Apigee style (form data in body)
+            content_length = int(self.headers.get('Content-Length', 0))
+            body = self.rfile.read(content_length).decode('utf-8')
+
+            # Parse form data
+            params = {}
+            for param in body.split('&'):
+                if '=' in param:
+                    key, value = param.split('=', 1)
+                    params[key] = value
+
+            if params.get("grant_type") != "client_credentials":
+                self._oauth_error("unsupported_grant_type")
+                return
+
+            if (params.get("client_id") == OAUTH_APIGEE_CLIENT_ID and
+                params.get("client_secret") == OAUTH_APIGEE_CLIENT_SECRET):
+                self._oauth_success("apigee")
+            else:
+                self._oauth_error("invalid_client")
         else:
             self.send_response(404)
             self.end_headers()

--- a/tests/hola/oauth_spec.lua
+++ b/tests/hola/oauth_spec.lua
@@ -1,0 +1,427 @@
+local oauth = require("hola.oauth")
+
+describe("hola oauth module", function()
+	-- Clear cache before each test
+	before_each(function()
+		oauth.clear_cache()
+	end)
+
+	describe("get_token", function()
+		it("should return error when OAuth configuration is missing", function()
+			local empty_sources = {{}}
+
+			local token, error = oauth.get_token("default", empty_sources)
+
+			assert.is_nil(token)
+			assert.matches("Missing OAuth configuration", error)
+		end)
+
+		it("should return error when OAuth request fails with 401", function()
+			-- Mock curl response
+			local curl = require('plenary.curl')
+			local original_post = curl.post
+			curl.post = function()
+				return {
+					status = 401,
+					body = '{"error": "invalid_client", "error_description": "Invalid credentials"}'
+				}
+			end
+
+			local env_sources = {{
+				OAUTH_TOKEN_URL = "http://test.com/token",
+				OAUTH_CLIENT_ID = "test_id",
+				OAUTH_CLIENT_SECRET = "test_secret"
+			}}
+
+			local token, error = oauth.get_token("default", env_sources)
+
+			assert.is_nil(token)
+			assert.matches("OAuth request failed with status 401", error)
+			assert.matches("invalid_client", error)
+
+			-- Restore original function
+			curl.post = original_post
+		end)
+
+		it("should return error when OAuth response is invalid JSON", function()
+			local curl = require('plenary.curl')
+			local original_post = curl.post
+			curl.post = function()
+				return {
+					status = 200,
+					body = 'invalid json'
+				}
+			end
+
+			local env_sources = {{
+				OAUTH_TOKEN_URL = "http://test.com/token",
+				OAUTH_CLIENT_ID = "test_id",
+				OAUTH_CLIENT_SECRET = "test_secret"
+			}}
+
+			local token, error = oauth.get_token("default", env_sources)
+
+			assert.is_nil(token)
+			assert.matches("Invalid OAuth response format", error)
+
+			curl.post = original_post
+		end)
+
+		it("should return error when OAuth response lacks access_token", function()
+			local curl = require('plenary.curl')
+			local original_post = curl.post
+			curl.post = function()
+				return {
+					status = 200,
+					body = '{"token_type": "Bearer", "expires_in": 3600}'
+				}
+			end
+
+			local env_sources = {{
+				OAUTH_TOKEN_URL = "http://test.com/token",
+				OAUTH_CLIENT_ID = "test_id",
+				OAUTH_CLIENT_SECRET = "test_secret"
+			}}
+
+			local token, error = oauth.get_token("default", env_sources)
+
+			assert.is_nil(token)
+			assert.matches("Invalid OAuth response format", error)
+
+			curl.post = original_post
+		end)
+
+		it("should successfully fetch and cache OAuth token with basic_auth", function()
+			local curl = require('plenary.curl')
+			local original_post = curl.post
+			local captured_request = nil
+
+			curl.post = function(url, options)
+				captured_request = {url = url, options = options}
+				return {
+					status = 200,
+					body = '{"access_token": "test_token_123", "token_type": "Bearer", "expires_in": 3600}'
+				}
+			end
+
+			local env_sources = {{
+				OAUTH_TOKEN_URL = "http://test.com/oauth/token",
+				OAUTH_CLIENT_ID = "test_client_id",
+				OAUTH_CLIENT_SECRET = "test_client_secret",
+				OAUTH_GRANT_TYPE = "client_credentials",
+				OAUTH_SCOPE = "read:users",
+				OAUTH_AUTH_METHOD = "basic_auth"
+			}}
+
+			local token, error = oauth.get_token("default", env_sources)
+
+			assert.is_nil(error)
+			assert.equals("test_token_123", token)
+
+			-- Verify request was made correctly
+			assert.equals("http://test.com/oauth/token", captured_request.url)
+			assert.equals("application/x-www-form-urlencoded", captured_request.options.headers["Content-Type"])
+			assert.matches("Basic ", captured_request.options.headers["Authorization"])
+			assert.equals("grant_type=client_credentials&scope=read:users", captured_request.options.body)
+
+			curl.post = original_post
+		end)
+
+		it("should successfully fetch OAuth token with form_data method", function()
+			local curl = require('plenary.curl')
+			local original_post = curl.post
+			local captured_request = nil
+
+			curl.post = function(url, options)
+				captured_request = {url = url, options = options}
+				return {
+					status = 200,
+					body = '{"access_token": "apigee_token_456", "token_type": "Bearer", "expires_in": 1800}'
+				}
+			end
+
+			local env_sources = {{
+				OAUTH_TOKEN_URL = "http://apigee.com/oauth/v2/accesstoken",
+				OAUTH_CLIENT_ID = "apigee_client",
+				OAUTH_CLIENT_SECRET = "apigee_secret",
+				OAUTH_AUTH_METHOD = "form_data"
+			}}
+
+			local token, error = oauth.get_token("default", env_sources)
+
+			assert.is_nil(error)
+			assert.equals("apigee_token_456", token)
+
+			-- Verify form_data method
+			assert.is_nil(captured_request.options.headers["Authorization"])
+			assert.matches("grant_type=client_credentials", captured_request.options.body)
+			assert.matches("client_id=apigee_client", captured_request.options.body)
+			assert.matches("client_secret=apigee_secret", captured_request.options.body)
+
+			curl.post = original_post
+		end)
+
+		it("should successfully fetch OAuth token with json_body method", function()
+			local curl = require('plenary.curl')
+			local original_post = curl.post
+			local captured_request = nil
+
+			curl.post = function(url, options)
+				captured_request = {url = url, options = options}
+				return {
+					status = 200,
+					body = '{"access_token": "auth0_token_789", "token_type": "Bearer", "expires_in": 86400}'
+				}
+			end
+
+			local env_sources = {{
+				OAUTH_TOKEN_URL = "http://auth0.com/oauth/token",
+				OAUTH_CLIENT_ID = "auth0_client",
+				OAUTH_CLIENT_SECRET = "auth0_secret",
+				OAUTH_AUTH_METHOD = "json_body",
+				OAUTH_AUDIENCE = "https://api.example.com"
+			}}
+
+			local token, error = oauth.get_token("default", env_sources)
+
+			assert.is_nil(error)
+			assert.equals("auth0_token_789", token)
+
+			-- Verify JSON body method
+			assert.equals("application/json", captured_request.options.headers["Content-Type"])
+			local body_data = vim.fn.json_decode(captured_request.options.body)
+			assert.equals("client_credentials", body_data.grant_type)
+			assert.equals("auth0_client", body_data.client_id)
+			assert.equals("auth0_secret", body_data.client_secret)
+			assert.equals("https://api.example.com", body_data.audience)
+
+			curl.post = original_post
+		end)
+
+		it("should handle multi-environment configurations", function()
+			local curl = require('plenary.curl')
+			local original_post = curl.post
+
+			curl.post = function()
+				return {
+					status = 200,
+					body = '{"access_token": "staging_token_999", "token_type": "Bearer", "expires_in": 3600}'
+				}
+			end
+
+			local env_sources = {{
+				-- Staging environment configuration
+				OAUTH_TOKEN_URL_STAGING = "http://staging-auth.com/token",
+				OAUTH_CLIENT_ID_STAGING = "staging_client",
+				OAUTH_CLIENT_SECRET_STAGING = "staging_secret"
+			}}
+
+			local token, error = oauth.get_token("staging", env_sources)
+
+			assert.is_nil(error)
+			assert.equals("staging_token_999", token)
+
+			curl.post = original_post
+		end)
+
+		it("should return cached token without making request", function()
+			local curl = require('plenary.curl')
+			local original_post = curl.post
+			local request_count = 0
+
+			curl.post = function()
+				request_count = request_count + 1
+				return {
+					status = 200,
+					body = '{"access_token": "cached_token_111", "token_type": "Bearer", "expires_in": 3600}'
+				}
+			end
+
+			local env_sources = {{
+				OAUTH_TOKEN_URL = "http://test.com/token",
+				OAUTH_CLIENT_ID = "test_id",
+				OAUTH_CLIENT_SECRET = "test_secret"
+			}}
+
+			-- First request should make HTTP call
+			local token1, error1 = oauth.get_token("default", env_sources)
+			assert.is_nil(error1)
+			assert.equals("cached_token_111", token1)
+			assert.equals(1, request_count)
+
+			-- Second request should use cache
+			local token2, error2 = oauth.get_token("default", env_sources)
+			assert.is_nil(error2)
+			assert.equals("cached_token_111", token2)
+			assert.equals(1, request_count) -- Should not have made another request
+
+			curl.post = original_post
+		end)
+
+		it("should handle custom headers configuration", function()
+			local curl = require('plenary.curl')
+			local original_post = curl.post
+			local captured_request = nil
+
+			curl.post = function(url, options)
+				captured_request = {url = url, options = options}
+				return {
+					status = 200,
+					body = '{"access_token": "custom_token_222", "token_type": "Bearer", "expires_in": 3600}'
+				}
+			end
+
+			local env_sources = {{
+				OAUTH_TOKEN_URL = "http://test.com/token",
+				OAUTH_CLIENT_ID = "test_id",
+				OAUTH_CLIENT_SECRET = "test_secret",
+				OAUTH_CUSTOM_HEADERS = "X-API-Version:2.0,X-Source:hola-nvim"
+			}}
+
+			local token, error = oauth.get_token("default", env_sources)
+
+			assert.is_nil(error)
+			assert.equals("custom_token_222", token)
+			assert.equals("2.0", captured_request.options.headers["X-API-Version"])
+			assert.equals("hola-nvim", captured_request.options.headers["X-Source"])
+
+			curl.post = original_post
+		end)
+	end)
+
+	describe("clear_cache", function()
+		it("should clear specific environment cache", function()
+			-- Setup mock and get tokens for different environments
+			local curl = require('plenary.curl')
+			local original_post = curl.post
+			curl.post = function()
+				return {
+					status = 200,
+					body = '{"access_token": "test_token", "token_type": "Bearer", "expires_in": 3600}'
+				}
+			end
+
+			local env_sources = {{
+				OAUTH_TOKEN_URL = "http://test.com/token",
+				OAUTH_CLIENT_ID = "test_id",
+				OAUTH_CLIENT_SECRET = "test_secret",
+				OAUTH_TOKEN_URL_STAGING = "http://staging.com/token",
+				OAUTH_CLIENT_ID_STAGING = "staging_id",
+				OAUTH_CLIENT_SECRET_STAGING = "staging_secret"
+			}}
+
+			-- Get tokens for both environments
+			oauth.get_token("default", env_sources)
+			oauth.get_token("staging", env_sources)
+
+			-- Verify both are in status
+			local status = oauth.get_status()
+			assert.is_not_nil(status.default)
+			assert.is_not_nil(status.staging)
+
+			-- Clear only staging
+			oauth.clear_cache("staging")
+
+			-- Verify only staging was cleared
+			local status_after = oauth.get_status()
+			assert.is_not_nil(status_after.default)
+			assert.is_nil(status_after.staging)
+
+			curl.post = original_post
+		end)
+
+		it("should clear all cache when no environment specified", function()
+			-- Similar setup as above but clear all
+			local curl = require('plenary.curl')
+			local original_post = curl.post
+			curl.post = function()
+				return {
+					status = 200,
+					body = '{"access_token": "test_token", "token_type": "Bearer", "expires_in": 3600}'
+				}
+			end
+
+			local env_sources = {{
+				OAUTH_TOKEN_URL = "http://test.com/token",
+				OAUTH_CLIENT_ID = "test_id",
+				OAUTH_CLIENT_SECRET = "test_secret"
+			}}
+
+			oauth.get_token("default", env_sources)
+
+			local status_before = oauth.get_status()
+			assert.is_not_nil(status_before.default)
+
+			oauth.clear_cache() -- Clear all
+
+			local status_after = oauth.get_status()
+			assert.equals(0, vim.tbl_count(status_after))
+
+			curl.post = original_post
+		end)
+	end)
+
+	describe("get_status", function()
+		it("should return empty status when no tokens cached", function()
+			local status = oauth.get_status()
+			assert.equals(0, vim.tbl_count(status))
+		end)
+
+		it("should return status information for cached tokens", function()
+			local curl = require('plenary.curl')
+			local original_post = curl.post
+			curl.post = function()
+				return {
+					status = 200,
+					body = '{"access_token": "status_token", "token_type": "Bearer", "expires_in": 1800}'
+				}
+			end
+
+			local env_sources = {{
+				OAUTH_TOKEN_URL = "http://test.com/token",
+				OAUTH_CLIENT_ID = "test_id",
+				OAUTH_CLIENT_SECRET = "test_secret"
+			}}
+
+			oauth.get_token("default", env_sources)
+
+			local status = oauth.get_status()
+			assert.is_not_nil(status.default)
+			assert.equals("Bearer", status.default.token_type)
+			assert.is_number(status.default.expires_at)
+			assert.is_number(status.default.acquired_at)
+			assert.is_boolean(status.default.expired)
+
+			curl.post = original_post
+		end)
+	end)
+
+	describe("get_cache_stats", function()
+		it("should return correct cache statistics", function()
+			local curl = require('plenary.curl')
+			local original_post = curl.post
+			curl.post = function()
+				return {
+					status = 200,
+					body = '{"access_token": "stats_token", "token_type": "Bearer", "expires_in": 3600}'
+				}
+			end
+
+			local env_sources = {{
+				OAUTH_TOKEN_URL = "http://test.com/token",
+				OAUTH_CLIENT_ID = "test_id",
+				OAUTH_CLIENT_SECRET = "test_secret"
+			}}
+
+			-- Get a token to populate cache
+			oauth.get_token("default", env_sources)
+
+			local stats = oauth.get_cache_stats()
+			assert.equals(1, stats.total_entries)
+			assert.equals(1, stats.valid_entries)
+			assert.equals(0, stats.expired_entries)
+
+			curl.post = original_post
+		end)
+	end)
+end)

--- a/tests/hola/utils_spec.lua
+++ b/tests/hola/utils_spec.lua
@@ -422,4 +422,284 @@ Content-Type: application/json
 			end)
 		end)
 	end)
+
+	describe("OAuth template processing", function()
+		describe("prepare_oauth_tokens", function()
+			it("should extract OAuth variables from text", function()
+				local request_text = [[
+GET /api/users
+Authorization: Bearer {{OAUTH_TOKEN}}
+X-Another-Header: {{OAUTH_TOKEN_STAGING}}
+]]
+
+				-- Mock OAuth module
+				local original_require = require
+				_G.require = function(name)
+					if name == 'hola.oauth' then
+						return {
+							get_token = function(env_suffix, env_sources)
+								if env_suffix == 'default' then
+									return 'default_token_123', nil
+								elseif env_suffix == 'staging' then
+									return 'staging_token_456', nil
+								end
+							end
+						}
+					end
+					return original_require(name)
+				end
+
+				local oauth_tokens, errors = utils.prepare_oauth_tokens(request_text, {})
+
+				assert.equals(0, #errors)
+				assert.equals('default_token_123', oauth_tokens['OAUTH_TOKEN'])
+				assert.equals('staging_token_456', oauth_tokens['OAUTH_TOKEN_STAGING'])
+
+				-- Restore require
+				_G.require = original_require
+			end)
+
+			it("should handle OAuth token fetch errors", function()
+				local request_text = 'Authorization: Bearer {{OAUTH_TOKEN}}'
+
+				-- Mock OAuth module that returns error
+				local original_require = require
+				_G.require = function(name)
+					if name == 'hola.oauth' then
+						return {
+							get_token = function(env_suffix, env_sources)
+								return nil, 'Missing OAuth configuration for environment: default'
+							end
+						}
+					end
+					return original_require(name)
+				end
+
+				local oauth_tokens, errors = utils.prepare_oauth_tokens(request_text, {})
+
+				assert.equals(1, #errors)
+				assert.equals('OAUTH_TOKEN', errors[1].variable)
+				assert.matches('Missing OAuth configuration', errors[1].error)
+
+				-- Restore require
+				_G.require = original_require
+			end)
+
+			it("should return empty when OAuth module not available", function()
+				local request_text = 'Authorization: Bearer {{OAUTH_TOKEN}}'
+
+				-- Mock require to fail loading oauth module
+				local original_require = require
+				_G.require = function(name)
+					if name == 'hola.oauth' then
+						error('module not found')
+					end
+					return original_require(name)
+				end
+
+				local oauth_tokens, errors = utils.prepare_oauth_tokens(request_text, {})
+
+				assert.equals(0, #errors)
+				assert.equals(0, vim.tbl_count(oauth_tokens))
+
+				-- Restore require
+				_G.require = original_require
+			end)
+		end)
+
+		describe("compile_template_with_providers", function()
+			it("should prioritize OAuth tokens over traditional sources", function()
+				local request_text = 'Authorization: Bearer {{OAUTH_TOKEN}}'
+				local traditional_sources = {{
+					OAUTH_TOKEN = 'should_not_use_this' -- This should be ignored
+				}}
+
+				-- Mock OAuth module
+				local original_require = require
+				_G.require = function(name)
+					if name == 'hola.oauth' then
+						return {
+							get_token = function(env_suffix, env_sources)
+								return 'oauth_fetched_token', nil
+							end
+						}
+					end
+					return original_require(name)
+				end
+
+				local compiled_text, errors = utils.compile_template_with_providers(request_text, traditional_sources)
+
+				assert.equals(0, #errors)
+				assert.equals('Authorization: Bearer oauth_fetched_token', compiled_text)
+
+				-- Restore require
+				_G.require = original_require
+			end)
+
+			it("should combine OAuth and traditional variables", function()
+				local request_text = [[
+Authorization: Bearer {{OAUTH_TOKEN}}
+X-API-Key: {{API_KEY}}
+]]
+				local traditional_sources = {{
+					API_KEY = 'traditional_api_key'
+				}}
+
+				-- Mock OAuth module
+				local original_require = require
+				_G.require = function(name)
+					if name == 'hola.oauth' then
+						return {
+							get_token = function(env_suffix, env_sources)
+								return 'oauth_token_123', nil
+							end
+						}
+					end
+					return original_require(name)
+				end
+
+				local compiled_text, errors = utils.compile_template_with_providers(request_text, traditional_sources)
+
+				assert.equals(0, #errors)
+				assert.matches('Bearer oauth_token_123', compiled_text)
+				assert.matches('X%-API%-Key: traditional_api_key', compiled_text)
+
+				-- Restore require
+				_G.require = original_require
+			end)
+
+			it("should aggregate errors from OAuth and providers", function()
+				local request_text = [[
+Authorization: Bearer {{OAUTH_TOKEN}}
+X-Vault-Secret: {{vault:secret/test#key}}
+]]
+
+				-- Mock modules to return errors
+				local original_require = require
+				_G.require = function(name)
+					if name == 'hola.oauth' then
+						return {
+							get_token = function(env_suffix, env_sources)
+								return nil, 'OAuth configuration missing'
+							end
+						}
+					elseif name == 'hola.providers' then
+						return {
+							extract_variables_from_text = function(text)
+								return {{ type = "provider", provider = "vault", path = "secret/test", field = "key", original_text = "vault:secret/test#key" }}
+							end,
+							resolve_provider_secret = function()
+								return nil, 'Vault not authenticated'
+							end,
+							is_provider_available = function() return true end
+						}
+					end
+					return original_require(name)
+				end
+
+				local compiled_text, errors = utils.compile_template_with_providers(request_text, {})
+
+				assert.equals(2, #errors)
+				-- Should have both OAuth and provider errors
+				local oauth_error = nil
+				local vault_error = nil
+				for _, err in ipairs(errors) do
+					if err.variable == 'OAUTH_TOKEN' then
+						oauth_error = err
+					elseif err.variable == 'vault:secret/test#key' then
+						vault_error = err
+					end
+				end
+				assert.is_not_nil(oauth_error)
+				assert.is_not_nil(vault_error)
+
+				-- Restore require
+				_G.require = original_require
+			end)
+
+			it("should handle whitespace in OAuth variable names", function()
+				local request_text = 'Authorization: Bearer {{ OAUTH_TOKEN_STAGING }}'
+
+				-- Mock OAuth module
+				local original_require = require
+				_G.require = function(name)
+					if name == 'hola.oauth' then
+						return {
+							get_token = function(env_suffix, env_sources)
+								assert.equals('staging', env_suffix)
+								return 'staging_token_with_whitespace', nil
+							end
+						}
+					end
+					return original_require(name)
+				end
+
+				local compiled_text, errors = utils.compile_template_with_providers(request_text, {})
+
+				assert.equals(0, #errors)
+				assert.equals('Authorization: Bearer staging_token_with_whitespace', compiled_text)
+
+				-- Restore require
+				_G.require = original_require
+			end)
+		end)
+
+		describe("compile_template OAuth error suppression", function()
+			it("should not show error for failed OAuth variables", function()
+				local request_text = 'Authorization: Bearer {{OAUTH_TOKEN}}'
+				local sources = {{}} -- Empty sources, no OAuth token available
+
+				-- Capture vim.notify calls
+				local notify_calls = {}
+				local original_notify = vim.notify
+				vim.notify = function(msg, level, opts)
+					table.insert(notify_calls, {msg = msg, level = level, opts = opts})
+				end
+
+				local compiled_text = utils.compile_template(request_text, sources)
+
+				-- Should not have shown OAuth error (OAuth errors handled separately)
+				local oauth_errors = {}
+				for _, call in ipairs(notify_calls) do
+					if call.msg:match('OAUTH_TOKEN') then
+						table.insert(oauth_errors, call)
+					end
+				end
+				assert.equals(0, #oauth_errors)
+
+				-- Should still have the template placeholder
+				assert.equals('Authorization: Bearer {{OAUTH_TOKEN}}', compiled_text)
+
+				-- Restore vim.notify
+				vim.notify = original_notify
+			end)
+
+			it("should show error for non-OAuth variables", function()
+				local request_text = 'X-API-Key: {{REGULAR_VAR}}'
+				local sources = {{}} -- Empty sources
+
+				-- Capture vim.notify calls
+				local notify_calls = {}
+				local original_notify = vim.notify
+				vim.notify = function(msg, level, opts)
+					table.insert(notify_calls, {msg = msg, level = level, opts = opts})
+				end
+
+				local compiled_text = utils.compile_template(request_text, sources)
+
+				-- Should have shown error for regular variable
+				local regular_errors = {}
+				for _, call in ipairs(notify_calls) do
+					if call.msg:match('REGULAR_VAR') then
+						table.insert(regular_errors, call)
+					end
+				end
+				assert.equals(1, #regular_errors)
+				assert.equals(vim.log.levels.ERROR, regular_errors[1].level)
+
+				-- Restore vim.notify
+				vim.notify = original_notify
+			end)
+		end)
+	end)
 end)


### PR DESCRIPTION
# Add OAuth 2.0 Server-to-Server Authentication Support

## Overview

Implements OAuth 2.0 client credentials flow for seamless server-to-server authentication with API gateways like AWS Cognito, Auth0, and Apigee.

## Key Features

- **Template Integration**: Use `{{OAUTH_TOKEN}}` in HTTP requests for automatic token handling
- **Multi-Environment**: Support for staging/prod environments (`{{OAUTH_TOKEN_STAGING}}`)
- **Secure Caching**: In-memory token storage with automatic refresh (no disk persistence)
- **Provider Support**: AWS Cognito, Auth0, Apigee, and custom OAuth servers

## Usage

### Configuration (.env)
```bash
  OAUTH_TOKEN_URL=https://auth.example.com/oauth/token
  OAUTH_CLIENT_ID=your_client_id
  OAUTH_CLIENT_SECRET=your_client_secret
```

HTTP Requests
```
GET https://api.example.com/users
Authorization: Bearer {{OAUTH_TOKEN}}
```

Tokens are automatically fetched, cached, and refreshed as needed.

Implementation

- New Module: lua/hola/oauth.lua - Core OAuth functionality
- Enhanced Utils: OAuth template processing integrated into existing system
- Comprehensive Tests: Unit tests and integration tests with mock server
- Documentation: Complete setup guide in OAUTH.md
