### PR TITLE
Add file download feature with @output directive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,10 +31,12 @@ To develop the plugin:
 
 **Request Processing Pipeline:**
 1. `utils.get_request_under_cursor()` - Extracts HTTP request text from cursor position
-2. `resolution.resolve_variables()` - Resolves template variables using provider system
-3. `utils.parse_request()` - Parses HTTP request syntax into structured data
-4. `request.execute()` - Executes async HTTP request via plenary.curl
-5. `ui.display_response()` - Shows response in split window with JSON formatting
+2. `utils.parse_output_directive()` - Extracts `@output` file directive from comments (if present)
+3. `resolution.resolve_variables()` - Resolves template variables using provider system
+4. `utils.parse_request()` - Parses HTTP request syntax into structured data
+5. `request.execute()` - Executes async HTTP request via plenary.curl
+6. `file_writer.save_response()` - Saves response to file if `@output` directive was specified
+7. `ui.display_response()` - Shows response in split window with JSON formatting
 
 **Key Modules:**
 
@@ -42,6 +44,7 @@ To develop the plugin:
   - HTTP request parsing with separator detection (`###` lines)
   - Header normalization and response filetype detection
   - Authentication header processing (Basic Auth encoding)
+  - Output directive parsing (`# @output filename`)
 
 - **`lua/hola/resolution.lua`** - Provider-based variable resolution
   - Unified template variable resolution using `{{provider:identifier}}` syntax
@@ -77,6 +80,12 @@ To develop the plugin:
   - Status indicators during request execution
   - Progress and error messages
 
+- **`lua/hola/file_writer.lua`** - File output and download
+  - Saves HTTP responses to files (similar to curl -o)
+  - Handles binary and text content
+  - Automatic directory creation
+  - Path expansion support (~, ., ..)
+
 **Provider System:**
 - **env**: Environment variables and `.env` files
 - **vault**: HashiCorp Vault secret retrieval
@@ -89,6 +98,7 @@ To develop the plugin:
 - Headers as `Key: Value` pairs
 - Blank line separates headers from body
 - Template variables: `{{provider:identifier}}` (e.g., `{{env:API_KEY}}`, `{{oauth:service}}`)
+- Output directive: `# @output filename` - Saves response to file (similar to curl -o)
 
 ### Command Interface
 
@@ -97,6 +107,7 @@ To develop the plugin:
 - `:HolaToggle` - Toggle between response body and metadata view
 - `:HolaClose` - Close response window
 - `:HolaFormatJson` - Toggle JSON formatting (formatted ↔ raw)
+- `:HolaSave <filename>` - Save the last response to a file
 
 
 ### Dependencies
@@ -112,4 +123,6 @@ Tests are located in `tests/` directory and use plenary.nvim's test framework. K
 - JSON formatting and processing
 - OAuth token management
 - Virtual text integration
+- File output and download functionality
+- Output directive parsing
 - Full integration testing

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Just add this to your `plugins` table in your Neovim configuration (using your p
   * `:HolaToggle`: Toggle between response body and metadata view
   * `:HolaClose`: Close response window
   * `:HolaFormatJson`: Toggle JSON formatting (formatted ↔ raw) ✨
+  * `:HolaSave <filename>`: Save the last response to a file 💾
 
 ## Example: Let's Send Some Requests! 📬
 
@@ -66,6 +67,60 @@ map({ "n", "v" }, "<leader>hc", "<cmd>:HolaClose<cr>", { desc = "Close response 
 -- Hola keymaps - JSON tools ✨
 map({ "n", "v" }, "<leader>hf", "<cmd>:HolaFormatJson<cr>", { desc = "Toggle JSON formatting" })
 ```
+
+## Download Files and Save Responses 💾
+
+`hola.nvim` makes it easy to download files and save HTTP responses directly to your filesystem, just like curl's `-o` flag!
+
+### Automatic File Saving with `@output`
+
+Add a comment directive to your request to automatically save the response to a file:
+
+```http
+# @output response.json
+GET https://api.example.com/data
+Accept: application/json
+```
+
+The response body will be saved to `response.json` in your current working directory. You can use:
+- **Relative paths**: `@output downloads/image.png`
+- **Absolute paths**: `@output /tmp/response.json`
+- **Home directory**: `@output ~/Downloads/file.pdf`
+
+### Downloading Binary Content
+
+Perfect for downloading images, PDFs, and other binary files:
+
+```http
+# @output screenshot.png
+GET https://example.com/images/screenshot.png
+Accept: image/png
+```
+
+```http
+# @output document.pdf
+GET https://example.com/files/document.pdf
+Accept: application/pdf
+```
+
+### Manual Saving with `:HolaSave`
+
+You can also save the last response manually after viewing it:
+
+1. Send a request with `:HolaSend`
+2. Review the response in the split window
+3. Save it with `:HolaSave filename.ext`
+
+```vim
+:HolaSave downloads/response.json
+```
+
+**Features:**
+- Automatically creates parent directories if they don't exist
+- Handles both text and binary content correctly
+- Works with all HTTP methods (GET, POST, etc.)
+- Supports path expansion (`~`, `.`, `..`)
+- Shows success/error notifications
 
 ## Beautiful JSON Responses with Smart Formatting! ✨
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,99 @@ You can also save the last response manually after viewing it:
 - Supports path expansion (`~`, `.`, `..`)
 - Shows success/error notifications
 
+### Testing the Download Feature
+
+Here's how to test the file download feature:
+
+**1. Test Automatic Saving with Local Server**
+
+First, start the test server:
+```bash
+python scripts/server.py
+```
+
+Create a test `.http` file:
+```http
+### Test automatic file saving
+# @output test_response.json
+GET http://localhost:8000/hello
+Accept: application/json
+
+### Test with nested directory
+# @output downloads/api/response.json
+GET http://localhost:8000/echo
+Content-Type: application/json
+
+{"test": "data"}
+```
+
+Place your cursor on the request and run `:HolaSend`. Check that:
+- `test_response.json` was created in the current directory
+- `downloads/api/response.json` was created with parent directories
+- Notification shows the saved file path
+
+**2. Test Manual Saving**
+
+Send a request without `@output`:
+```http
+GET http://localhost:8000/hello
+```
+
+After the response appears, run:
+```vim
+:HolaSave manual_save.json
+```
+
+Verify the file was created and contains the response body.
+
+**3. Test with Real APIs**
+
+Test downloading actual images or files:
+```http
+# @output test_image.png
+GET https://httpbin.org/image/png
+Accept: image/png
+```
+
+After running `:HolaSend`:
+- Check that `test_image.png` exists
+- Verify it's a valid image: `file test_image.png` (should show PNG image data)
+- Open it to confirm: `xdg-open test_image.png` (Linux) or `open test_image.png` (macOS)
+
+**4. Test Binary Content**
+
+```http
+# @output test_data.bin
+GET https://httpbin.org/bytes/1024
+```
+
+Verify the file size: `ls -lh test_data.bin` (should be ~1KB)
+
+**5. Test Path Expansion**
+
+```http
+# @output ~/Downloads/hola_test.json
+GET https://httpbin.org/json
+```
+
+Check that the file was saved to your Downloads folder.
+
+**6. Test Error Handling**
+
+Try invalid paths to verify error messages:
+```vim
+:HolaSave /root/forbidden.txt
+```
+
+You should see an error notification if you don't have write permissions.
+
+**Cleanup:**
+```bash
+# Remove test files
+rm -f test_response.json manual_save.json test_image.png test_data.bin
+rm -rf downloads/
+```
+
 ## Beautiful JSON Responses with Smart Formatting! ✨
 
 `hola.nvim` automatically detects JSON responses and provides powerful formatting and syntax highlighting features to make working with JSON a breeze.
@@ -384,12 +477,41 @@ nvim --headless -u scripts/init.lua \
   -c "qa"
 ```
 
+**Testing the File Download Feature:**
+
+Use the provided test file for comprehensive testing:
+
+```bash
+# 1. Start the test server
+python scripts/server.py
+
+# 2. Open the test file
+nvim -u scripts/init.lua test_download.http
+
+# 3. Run each test request with :HolaSend
+# 4. Verify files were created correctly
+ls -R test_outputs/
+
+# 5. Clean up
+rm -rf test_outputs/
+```
+
+The `test_download.http` file includes tests for:
+- Basic automatic saving
+- Nested directory creation
+- Manual saving with `:HolaSave`
+- Binary content (images, raw bytes)
+- Path expansion (~, ., ..)
+- POST requests with output
+- Error handling
+
 ### Project Structure
 
 - `lua/hola/` - Core plugin code
 - `lua/hola/resolution/` - Provider system for variable resolution
 - `tests/` - Test suite using plenary.nvim
 - `examples.http` - Example requests showcasing features
+- `test_download.http` - Comprehensive tests for file download feature
 - `.env.example` - Template for environment variables
 - `oauth.toml` - OAuth provider configurations
 - `refs` - Reference aliases for variables

--- a/examples.http
+++ b/examples.http
@@ -112,3 +112,20 @@ Content-Type: application/json
   "version": "{{env:VERSION}}",
   "message": "Multi-provider example - OAuth + env + refs"
 }
+
+### =============================================================================
+### File Output (Download Responses)
+### =============================================================================
+
+### Save response to a file using @output directive
+# @output response.json
+GET http://localhost:8000/hello
+Accept: application/json
+
+### Download binary content (images, PDFs, etc.)
+# @output downloads/image.png
+# GET https://example.com/image.png
+# Accept: image/png
+
+### After receiving a response, you can also save it manually using:
+# :HolaSave filename.ext

--- a/lua/hola/file_writer.lua
+++ b/lua/hola/file_writer.lua
@@ -1,0 +1,85 @@
+local M = {}
+
+--- Ensures the parent directory exists for a given file path.
+-- Creates all necessary parent directories if they don't exist.
+-- @param file_path (string) The file path for which to ensure parent directory exists.
+-- @return (boolean, string|nil) True if directory exists/was created, false and error message otherwise.
+local function _ensure_parent_directory(file_path)
+	-- Get the parent directory
+	local parent_dir = vim.fn.fnamemodify(file_path, ":h")
+
+	-- Check if parent directory exists
+	if vim.fn.isdirectory(parent_dir) == 0 then
+		-- Try to create the directory and all parents
+		local result = vim.fn.mkdir(parent_dir, "p")
+		if result == 0 then
+			return false, "Failed to create directory: " .. parent_dir
+		end
+	end
+
+	return true
+end
+
+--- Writes binary or text content to a file.
+-- Creates parent directories if they don't exist.
+-- Handles both relative and absolute paths.
+-- @param file_path (string) The path where to save the file.
+-- @param content (string) The content to write to the file.
+-- @return (boolean, string|nil) True if successful, false and error message otherwise.
+function M.write_file(file_path, content)
+	-- Validate inputs
+	if not file_path or file_path == "" then
+		return false, "File path cannot be empty"
+	end
+
+	if not content then
+		content = ""
+	end
+
+	-- Expand the file path (handle ~, ., .., etc.)
+	local expanded_path = vim.fn.expand(file_path)
+
+	-- Ensure parent directory exists
+	local dir_ok, dir_err = _ensure_parent_directory(expanded_path)
+	if not dir_ok then
+		return false, dir_err
+	end
+
+	-- Write the file using Lua's io library (handles binary content)
+	local file, err = io.open(expanded_path, "wb")
+	if not file then
+		return false, "Failed to open file for writing: " .. (err or "unknown error")
+	end
+
+	local write_ok, write_err = file:write(content)
+	if not write_ok then
+		file:close()
+		return false, "Failed to write to file: " .. (write_err or "unknown error")
+	end
+
+	file:close()
+
+	return true, expanded_path
+end
+
+--- Saves an HTTP response to a file.
+-- Extracts the body from the response and writes it to the specified file.
+-- @param response (table) The response object containing the body field.
+-- @param file_path (string) The path where to save the response.
+-- @return (boolean, string|nil) True and actual file path if successful, false and error message otherwise.
+function M.save_response(response, file_path)
+	-- Validate response
+	if not response or type(response) ~= "table" then
+		return false, "Invalid response object"
+	end
+
+	-- Get the response body
+	local body = response.body or ""
+
+	-- Write to file
+	local ok, result = M.write_file(file_path, body)
+
+	return ok, result
+end
+
+return M

--- a/lua/hola/init.lua
+++ b/lua/hola/init.lua
@@ -5,6 +5,7 @@ local config = require("hola.config")
 local vault_health = require("hola.vault_health")
 local virtual_text = require("hola.virtual_text")
 local resolution = require("hola.resolution")
+local file_writer = require("hola.file_writer")
 
 local M = {}
 
@@ -34,6 +35,33 @@ function M.toggle_json_format()
 	ui.toggle_json_format()
 end
 
+--- Saves the last response to a file
+-- @param file_path (string) The path where to save the response
+function M.save_last_response(file_path)
+	-- Get the last response
+	local last_response = ui.get_last_response()
+
+	if not last_response then
+		vim.notify("No response to save", vim.log.levels.WARN)
+		return
+	end
+
+	-- Validate file path
+	if not file_path or vim.fn.trim(file_path) == "" then
+		vim.notify("Please provide a file path", vim.log.levels.ERROR)
+		return
+	end
+
+	-- Save the response
+	local save_ok, save_result = file_writer.save_response(last_response, file_path)
+
+	if save_ok then
+		vim.notify("Response saved to: " .. save_result, vim.log.levels.INFO)
+	else
+		vim.notify("Failed to save response: " .. save_result, vim.log.levels.ERROR)
+	end
+end
+
 function M.run_request_under_cursor()
 	-- 1. Get request text
 	local request_text = utils.get_request_under_cursor()
@@ -42,7 +70,10 @@ function M.run_request_under_cursor()
 		return
 	end
 
-	-- 2. Basic validation (optional, parse might handle some)
+	-- 2. Parse output directive before removing comments
+	local output_file = utils.parse_output_directive(request_text)
+
+	-- 3. Basic validation (optional, parse might handle some)
 	if not utils.validate_request_text(request_text) then
 		vim.notify("Invalid request structure.", vim.log.levels.ERROR)
 		return
@@ -80,6 +111,18 @@ function M.run_request_under_cursor()
 			virtual_text.show_error("request", result.error)
 		else
 			virtual_text.show_request_success(result.status, result.elapsed_ms)
+
+			-- Save to file if output directive was specified
+			if output_file then
+				local save_ok, save_result = file_writer.save_response(result, output_file)
+				if save_ok then
+					vim.notify("Response saved to: " .. save_result, vim.log.levels.INFO)
+				else
+					vim.notify("Failed to save response: " .. save_result, vim.log.levels.ERROR)
+				end
+			end
+
+			-- Display response in UI
 			ui.display_response(result)
 		end
 	end

--- a/lua/hola/ui.lua
+++ b/lua/hola/ui.lua
@@ -511,4 +511,10 @@ function M.clear_sending_feedback(feedback_info)
 	return { buf = buf, win = win }
 end
 
+--- Gets the last response that was displayed.
+-- @return (table|nil) The last response object, or nil if no response exists.
+function M.get_last_response()
+	return state.last_response
+end
+
 return M

--- a/lua/hola/utils.lua
+++ b/lua/hola/utils.lua
@@ -165,6 +165,36 @@ local function _get_lines_as_string(bufnr, start_line_1based, end_line_1based)
 	return vim.fn.trim(request_text) -- Trim leading/trailing whitespace/newlines
 end
 
+--- Extracts output file directive from comment lines.
+-- Looks for '# @output filename' directive in the request text.
+-- @param str (string) The input multi-line string.
+-- @return (string|nil) The output filename if found, nil otherwise.
+function M.parse_output_directive(str)
+	-- Handle nil or empty input gracefully
+	if not str or str == "" then
+		return nil
+	end
+
+	-- Split the input string into a table of lines.
+	local lines = vim.split(str, "\n")
+
+	-- Iterate through the lines looking for @output directive
+	for _, line in ipairs(lines) do
+		-- Check if the line is a comment with @output directive
+		-- Pattern: optional whitespace, #, optional whitespace, @output, whitespace, filename
+		local output_file = line:match("^%s*#%s*@output%s+(.+)%s*$")
+		if output_file then
+			-- Trim any remaining whitespace from the filename
+			output_file = vim.fn.trim(output_file)
+			if output_file ~= "" then
+				return output_file
+			end
+		end
+	end
+
+	return nil
+end
+
 --- Removes lines that consist entirely of comments.
 -- A comment line starts with '#', potentially preceded by whitespace.
 -- Preserves blank lines and lines that have non-comment content.

--- a/plugin/hola.lua
+++ b/plugin/hola.lua
@@ -30,6 +30,15 @@ end, {
 	desc = "Toggle JSON formatting between formatted and raw views",
 })
 
+vim.api.nvim_create_user_command("HolaSave", function(opts)
+	local file_path = opts.args
+	require("hola").save_last_response(file_path)
+end, {
+	nargs = 1,
+	desc = "Save the last response to a file",
+	complete = "file",
+})
+
 -- Debug commands for the new resolution system
 vim.api.nvim_create_user_command("HolaDebug", function(opts)
 	require("hola.resolution.debug").debug_command(opts)

--- a/test_download.http
+++ b/test_download.http
@@ -1,0 +1,98 @@
+### =============================================================================
+### File Download Feature - Test Suite
+### =============================================================================
+### This file contains comprehensive tests for the file download feature.
+### Start the test server first: python scripts/server.py
+###
+### Usage:
+### 1. Place cursor on any request below
+### 2. Run :HolaSend
+### 3. Check that the file was created correctly
+### =============================================================================
+
+### Test 1: Basic automatic saving (JSON)
+# @output test_outputs/basic.json
+GET http://localhost:8000/hello
+Accept: application/json
+
+### Test 2: Automatic saving with nested directories
+# @output test_outputs/nested/dir/response.json
+GET http://localhost:8000/echo
+Content-Type: application/json
+
+{
+  "test": "automatic directory creation",
+  "timestamp": "2025-01-01T00:00:00Z"
+}
+
+### Test 3: Request without @output (for manual saving test)
+# After this request completes, run: :HolaSave test_outputs/manual_save.json
+GET http://localhost:8000/hello
+Accept: application/json
+
+### Test 4: Download from real API - Image (PNG)
+### Uncomment to test with real API (requires internet)
+# # @output test_outputs/test_image.png
+# GET https://httpbin.org/image/png
+# Accept: image/png
+
+### Test 5: Download from real API - JSON
+### Uncomment to test with real API (requires internet)
+# # @output test_outputs/httpbin_data.json
+# GET https://httpbin.org/json
+# Accept: application/json
+
+### Test 6: Download binary data
+### Uncomment to test with real API (requires internet)
+# # @output test_outputs/binary_data.bin
+# GET https://httpbin.org/bytes/1024
+
+### Test 7: Path expansion - Home directory
+### Uncomment to test (saves to your actual home directory)
+# # @output ~/hola_test_download.json
+# GET http://localhost:8000/hello
+# Accept: application/json
+
+### Test 8: Relative path from current directory
+# @output ./test_outputs/relative_path.json
+GET http://localhost:8000/hello
+Accept: application/json
+
+### Test 9: POST request with output
+# @output test_outputs/post_response.json
+POST http://localhost:8000/echo
+Content-Type: application/json
+
+{
+  "method": "POST",
+  "message": "Testing POST with file output"
+}
+
+### Test 10: Large response
+# @output test_outputs/stats.json
+GET http://localhost:8000/stats
+Accept: application/json
+
+### =============================================================================
+### Verification Commands
+### =============================================================================
+### Run these commands in your terminal after testing:
+###
+### 1. Check all files were created:
+###    ls -R test_outputs/
+###
+### 2. Verify file contents:
+###    cat test_outputs/basic.json
+###    cat test_outputs/nested/dir/response.json
+###
+### 3. Check file sizes:
+###    ls -lh test_outputs/
+###
+### 4. Verify JSON is valid:
+###    cat test_outputs/basic.json | jq .
+###
+### 5. Clean up test files:
+###    rm -rf test_outputs/
+###    rm -f ~/hola_test_download.json  # if you tested home directory
+###
+### =============================================================================

--- a/tests/hola/file_writer_spec.lua
+++ b/tests/hola/file_writer_spec.lua
@@ -1,0 +1,199 @@
+local file_writer = require("hola.file_writer")
+
+describe("hola.file_writer", function()
+	local temp_dir
+	local temp_file
+
+	before_each(function()
+		-- Create a temporary directory for testing
+		temp_dir = vim.fn.tempname()
+		vim.fn.mkdir(temp_dir, "p")
+		temp_file = temp_dir .. "/test_output.txt"
+	end)
+
+	after_each(function()
+		-- Clean up temporary directory and files
+		if vim.fn.isdirectory(temp_dir) == 1 then
+			vim.fn.delete(temp_dir, "rf")
+		end
+	end)
+
+	describe("write_file", function()
+		it("writes text content to a file", function()
+			local content = "Hello, World!"
+			local ok, path = file_writer.write_file(temp_file, content)
+
+			assert.is_true(ok)
+			assert.are.equal(vim.fn.expand(temp_file), path)
+
+			-- Verify file exists and contains correct content
+			local file = io.open(temp_file, "r")
+			local read_content = file:read("*all")
+			file:close()
+
+			assert.are.equal(content, read_content)
+		end)
+
+		it("writes binary content to a file", function()
+			-- Create some binary content (e.g., a simple PNG header)
+			local binary_content = "\137\080\078\071\013\010\026\010"
+			local ok, path = file_writer.write_file(temp_file, binary_content)
+
+			assert.is_true(ok)
+
+			-- Verify file exists and contains correct binary content
+			local file = io.open(temp_file, "rb")
+			local read_content = file:read("*all")
+			file:close()
+
+			assert.are.equal(binary_content, read_content)
+		end)
+
+		it("creates parent directories if they don't exist", function()
+			local nested_file = temp_dir .. "/nested/dir/file.txt"
+			local content = "Nested file content"
+			local ok, path = file_writer.write_file(nested_file, content)
+
+			assert.is_true(ok)
+
+			-- Verify file exists
+			assert.are.equal(1, vim.fn.filereadable(nested_file))
+
+			-- Verify content
+			local file = io.open(nested_file, "r")
+			local read_content = file:read("*all")
+			file:close()
+
+			assert.are.equal(content, read_content)
+		end)
+
+		it("handles empty content", function()
+			local ok, path = file_writer.write_file(temp_file, "")
+
+			assert.is_true(ok)
+
+			-- Verify file exists and is empty
+			local file = io.open(temp_file, "r")
+			local read_content = file:read("*all")
+			file:close()
+
+			assert.are.equal("", read_content)
+		end)
+
+		it("handles nil content as empty", function()
+			local ok, path = file_writer.write_file(temp_file, nil)
+
+			assert.is_true(ok)
+
+			-- Verify file exists and is empty
+			local file = io.open(temp_file, "r")
+			local read_content = file:read("*all")
+			file:close()
+
+			assert.are.equal("", read_content)
+		end)
+
+		it("returns error for empty file path", function()
+			local ok, err = file_writer.write_file("", "content")
+
+			assert.is_false(ok)
+			assert.is_not_nil(err)
+			assert.is_string(err)
+		end)
+
+		it("expands ~ in file paths", function()
+			-- Skip this test if $HOME is not set
+			if not vim.env.HOME then
+				pending("HOME environment variable not set")
+				return
+			end
+
+			local home_file = "~/test_hola_output.txt"
+			local content = "Home directory test"
+			local ok, path = file_writer.write_file(home_file, content)
+
+			assert.is_true(ok)
+
+			-- Clean up
+			local expanded_path = vim.fn.expand(home_file)
+			if vim.fn.filereadable(expanded_path) == 1 then
+				vim.fn.delete(expanded_path)
+			end
+		end)
+	end)
+
+	describe("save_response", function()
+		it("saves response body to a file", function()
+			local response = {
+				status = 200,
+				body = '{"message": "success"}',
+				headers = {},
+			}
+
+			local ok, path = file_writer.save_response(response, temp_file)
+
+			assert.is_true(ok)
+
+			-- Verify content
+			local file = io.open(temp_file, "r")
+			local read_content = file:read("*all")
+			file:close()
+
+			assert.are.equal(response.body, read_content)
+		end)
+
+		it("handles response with no body", function()
+			local response = {
+				status = 204,
+				headers = {},
+			}
+
+			local ok, path = file_writer.save_response(response, temp_file)
+
+			assert.is_true(ok)
+
+			-- Verify file is empty
+			local file = io.open(temp_file, "r")
+			local read_content = file:read("*all")
+			file:close()
+
+			assert.are.equal("", read_content)
+		end)
+
+		it("handles binary response (image data)", function()
+			-- Simulate an image response with binary data
+			local response = {
+				status = 200,
+				body = "\137\080\078\071\013\010\026\010", -- PNG header
+				headers = { ["content-type"] = "image/png" },
+			}
+
+			local ok, path = file_writer.save_response(response, temp_file)
+
+			assert.is_true(ok)
+
+			-- Verify binary content is preserved
+			local file = io.open(temp_file, "rb")
+			local read_content = file:read("*all")
+			file:close()
+
+			assert.are.equal(response.body, read_content)
+		end)
+
+		it("returns error for invalid response", function()
+			local ok, err = file_writer.save_response(nil, temp_file)
+
+			assert.is_false(ok)
+			assert.is_not_nil(err)
+			assert.is_string(err)
+		end)
+
+		it("returns error for invalid response type", function()
+			local ok, err = file_writer.save_response("not a table", temp_file)
+
+			assert.is_false(ok)
+			assert.is_not_nil(err)
+			assert.is_string(err)
+		end)
+	end)
+end)

--- a/tests/hola/utils_spec.lua
+++ b/tests/hola/utils_spec.lua
@@ -73,6 +73,47 @@ describe("hola.utils", function()
 			assert.are.equal(expected, actual)
 		end)
 	end)
+	describe("parse_output_directive", function()
+		it("extracts output filename from @output directive", function()
+			local input = "# @output image.png\nGET http://example.com/image.png"
+			local expected = "image.png"
+			assert.are.equal(expected, utils.parse_output_directive(input))
+		end)
+
+		it("handles whitespace around directive", function()
+			local input = "#  @output   image.png  \nGET http://example.com/image.png"
+			local expected = "image.png"
+			assert.are.equal(expected, utils.parse_output_directive(input))
+		end)
+
+		it("handles paths with directories", function()
+			local input = "# @output downloads/images/photo.jpg\nGET http://example.com/photo.jpg"
+			local expected = "downloads/images/photo.jpg"
+			assert.are.equal(expected, utils.parse_output_directive(input))
+		end)
+
+		it("returns nil when no @output directive", function()
+			local input = "# This is a comment\nGET http://example.com/api"
+			assert.is_nil(utils.parse_output_directive(input))
+		end)
+
+		it("returns nil for empty input", function()
+			assert.is_nil(utils.parse_output_directive(""))
+			assert.is_nil(utils.parse_output_directive(nil))
+		end)
+
+		it("ignores @output in non-comment lines", function()
+			local input = "GET http://example.com/@output/test"
+			assert.is_nil(utils.parse_output_directive(input))
+		end)
+
+		it("finds first @output directive when multiple present", function()
+			local input = "# @output first.png\n# @output second.png\nGET http://example.com"
+			local expected = "first.png"
+			assert.are.equal(expected, utils.parse_output_directive(input))
+		end)
+	end)
+
 	describe("remove_comments", function()
 		it("removes comments", function()
 			local input = "# localhost\nPOST http://localhost"


### PR DESCRIPTION
This commit adds a new feature to download HTTP responses to files, similar to curl's -o flag. Users can now save responses automatically using a comment directive or manually using a new command.

Features added:
- Parse @output directive from comments in .http files
- Automatically save responses to specified files
- New :HolaSave command for manual response saving
- Support for both text and binary content (images, PDFs, etc.)
- Automatic directory creation for output paths
- Path expansion support (~, ., ..)

Implementation details:
- Added parse_output_directive() to utils.lua
- Created file_writer.lua module for file operations
- Updated init.lua to handle output directives in request flow
- Added get_last_response() to ui.lua for manual saving
- Added :HolaSave command to plugin/hola.lua

Testing:
- Added comprehensive tests for parse_output_directive()
- Added file_writer_spec.lua with tests for all file operations
- Added examples to examples.http

Documentation:
- Updated README.md with download feature documentation
- Updated CLAUDE.md with architectural information
- Added examples for both automatic and manual saving